### PR TITLE
Replace broken link to deployment ebook with archive.org permalink

### DIFF
--- a/_posts/12-05-01-Building-your-Application.md
+++ b/_posts/12-05-01-Building-your-Application.md
@@ -100,7 +100,7 @@ PHP.
 [Deployer]: http://deployer.org/
 [Rocketeer]: http://rocketeer.autopergamene.eu/
 [Magallanes]: http://magephp.com/
-[expert_php_deployments]: http://viccherubini.com/assets/Expert-PHP-Deployments.pdf
+[expert_php_deployments]: http://web.archive.org/web/20150706110149/https://leftnode.org/assets/expert-php-deployments.pdf
 [deploying_php_applications]: http://www.deployingphpapplications.com
 [Ansible]: https://www.ansible.com/
 [Puppet]: https://puppet.com/


### PR DESCRIPTION
In the [_Building and Deploying_ section](http://www.phptherightway.com/#building_and_deploying_your_application), under _Further Reading_, the link to the "Expert PHP Deployments" ebook is no longer valid.  This patch is to replace the broken link (to a private domain) with a "permalink" on archive.org.